### PR TITLE
Optionally fail requests with 503

### DIFF
--- a/cmd/allspark/main.go
+++ b/cmd/allspark/main.go
@@ -95,6 +95,11 @@ func main() {
 	}
 	var wg sync.WaitGroup
 
+	errorRate := viper.GetFloat64("ERROR_RATE")
+	if errorRate < 0.0 || errorRate > 1.0 {
+		panic(fmt.Sprintf("Error rate (%f) is out of range: [0.0, 1.0]", errorRate))
+	}
+
 	// HTTP server
 	wg.Add(1)
 	go func() {
@@ -113,6 +118,7 @@ func main() {
 		}
 
 		srv.SetRequests(httpRequests)
+		srv.SetErrorRate(errorRate)
 		srv.Run()
 	}()
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?
A new env var `ERROR_RATE` which specifies the rate at which the response status code should
be set to 503.

### Why?
To make it easy to simulate errors.

