### PR TITLE
Remove default kafka bootstrap consumer behavior

### DIFF
--- a/cmd/allspark/main.go
+++ b/cmd/allspark/main.go
@@ -184,28 +184,30 @@ func main() {
 		srv.Run()
 	}()
 
-	// Kafka server
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		consumer := kafka.NewConsumer(configuration.KafkaServer.BootstrapServer, configuration.KafkaServer.Topic, configuration.KafkaServer.ConsumerGroup, logger)
-		srv := server.New(consumer, logger, errorHandler)
-		if wl != nil {
-			srv.SetWorkload(wl)
-		}
+	if configuration.KafkaServer.BootstrapServer != "" {
+		// Kafka server
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			consumer := kafka.NewConsumer(configuration.KafkaServer.BootstrapServer, configuration.KafkaServer.Topic, configuration.KafkaServer.ConsumerGroup, logger)
+			srv := server.New(consumer, logger, errorHandler)
+			if wl != nil {
+				srv.SetWorkload(wl)
+			}
 
-		kafkaRequests, err := request.CreateRequestsFromStringSlice(viper.GetStringSlice("kafkaRequests"), logger.WithField("server", "kafka"))
-		if err != nil {
-			panic(err)
-		}
-		if len(kafkaRequests) == 0 {
-			kafkaRequests = requests
-		}
+			kafkaRequests, err := request.CreateRequestsFromStringSlice(viper.GetStringSlice("kafkaRequests"), logger.WithField("server", "kafka"))
+			if err != nil {
+				panic(err)
+			}
+			if len(kafkaRequests) == 0 {
+				kafkaRequests = requests
+			}
 
-		srv.SetRequests(kafkaRequests)
-		srv.SetSQLClient(sqlClient)
-		srv.Run()
-	}()
+			srv.SetRequests(kafkaRequests)
+			srv.SetSQLClient(sqlClient)
+			srv.Run()
+		}()
+	}
 
 	wg.Wait()
 }

--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -74,10 +74,6 @@ func (c *Consumer) Close() error {
 }
 
 func (c *Consumer) Validate() (*Consumer, error) {
-	if c.BootstrapServer == "" {
-		c.BootstrapServer = "kafka-all-broker.kafka:29092"
-	}
-
 	if c.ConsumerGroup == "" {
 		c.ConsumerGroup = "allspark-consumer-group"
 	}


### PR DESCRIPTION
Remove the default settings in the bootstrap kafka server validator and only create a consumer if the settings are actually configured.

| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Only create a kafka consumer if explicitly set.  Prior to this fix, the "bootstrap" kafka consumer was always being created even if there were no "KAFKASERVER_*" settings.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
It's confusing to have an arbitrary default kafka consumer register with the kafka server without specifically configuring allspark to do that.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
