### PR TITLE
Support Allspark deployment RHOS 4-11+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
 ARG GO_VERSION=1.18.0
+ARG GID=1000
+ARG UID=1000
 
 FROM golang:${GO_VERSION}-alpine3.15 AS builder
+ARG GID
+ARG UID
 
-RUN apk add --update --no-cache ca-certificates~=20211220 make~=4.3 git~=2.34 curl~=7.80
+# Create user and group
+RUN addgroup -g ${GID} -S appgroup && \
+    adduser -u ${UID} -S appuser -G appgroup
+
+RUN apk add --update --no-cache ca-certificates~=20220614 make~=4.3 git~=2.34 curl~=7.80
 
 ARG PACKAGE=/build
 
@@ -17,7 +25,14 @@ RUN BUILD_DIR='' BINARY_NAME=app make build-release
 
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/static:latest
+ARG GID
+ARG UID
+
 COPY --from=builder /app /app
 ENV GIN_MODE=release
-USER nobody:nobody
+
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+USER ${UID}:${GID}
+
 CMD ["/app"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,6 +1,6 @@
 FROM alpine:3.15.4
 
-RUN apk add --update --no-cache ca-certificates~=20211220
+RUN apk add --update --no-cache ca-certificates~=20220614
 
 ARG BUILD_DIR
 ARG BINARY_NAME

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ DOCKER_TAG ?= ${VERSION}
 # Dependency versions
 GOLANGCI_VERSION = 1.45.0
 GOLANG_VERSION = 1.18
-LICENSEI_VERSION = 0.6.1
+LICENSEI_VERSION = 0.7.0
 
 # Add the ability to override some variables
 # Use with care
@@ -64,14 +64,25 @@ build-debug: GOARGS += -gcflags "all=-N -l"
 build-debug: BINARY_NAME_SUFFIX += debug
 build-debug: build ## Build a binary with remote debugging capabilities
 
-.PHONY: docker
-docker: export GOOS = linux
-docker: BINARY_NAME_SUFFIX += docker
-docker: build-release ## Build a Docker image
-	docker build --build-arg BUILD_DIR=${BUILD_DIR} --build-arg BINARY_NAME=${GENERATED_BINARY_NAME} -t ${DOCKER_IMAGE}:${DOCKER_TAG} -f Dockerfile.local .
+.PHONY: docker-build
+docker-build: export GOOS = linux
+
+docker-build: BINARY_NAME_SUFFIX += docker
+docker-build: build-release ## Build a Docker image
+	docker build --build-arg BUILD_DIR=${BUILD_DIR} --build-arg BINARY_NAME=${GENERATED_BINARY_NAME} -t ${DOCKER_IMAGE}:${DOCKER_TAG} -f Dockerfile .
 ifeq (${DOCKER_LATEST}, 1)
 	docker tag ${DOCKER_IMAGE}:${DOCKER_TAG} ${DOCKER_IMAGE}:latest
 endif
+
+.PHONY: docker-local
+docker-local: export GOOS = linux
+docker-local: BINARY_NAME_SUFFIX += docker
+docker-local: build-release ## Build a Docker image
+	docker build --build-arg BUILD_DIR=${BUILD_DIR} --build-arg BINARY_NAME=${GENERATED_BINARY_NAME} -t ${DOCKER_IMAGE}:${DOCKER_TAG} -f Dockerfile.local .
+
+.PHONY: docker-push
+docker-push:			## Push the docker image (to override image name please set IMG)
+	docker push ${DOCKER_IMAGE}:${DOCKER_TAG}
 
 .PHONY: check
 check: test-all lint ## Run tests and linters


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes (Run on RHOS 4.11+)
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
1. Support allspark deployment on RHOS 4.11+ by modifying securityContext and podSecurityContext
2. Correct `.gitignore` file
3. Add `.licensei.cache` file to reduce rate limiting and cache already checked sources
4. Modify Makefile to support release dockerfile build and local dockerfile build

### Why?
Allspark deployment uses nobody user which is not supported on RHOS, hence modifying Dockerfile to use user 1000:1000 appuser:appgroup

### Additional context
WIP

### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)